### PR TITLE
Allow running script directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,13 @@ Cette application Streamlit permet d'afficher vos kanji, vocabulaire et statisti
    ```bash
    pip install -r requirements.txt
    ```
-2. Lancez l'application :
+2. Lancez l'application avec Streamlit ou directement via Python :
    ```bash
+   # méthode conseillée
    streamlit run wanikani_dashboard/app.py
+   
+   # ou en mode script simple
+   python wanikani_dashboard/app.py
    ```
 
 ## Fonctionnalités
@@ -17,6 +21,7 @@ Cette application Streamlit permet d'afficher vos kanji, vocabulaire et statisti
 - Affichage du nombre de kanji et de vocabulaire appris.
 - Tableau des reviews à venir sur les prochaines 24h.
 - Liste détaillée des kanji et du vocabulaire avec leur signification traduite en français.
+- Graphique de progression par niveau pour visualiser vos avancées.
 - Possibilité de se déconnecter ou de rafraîchir les données.
 
 ## Notes


### PR DESCRIPTION
## Summary
- let app run directly without Streamlit
- tweak the theme with Japanese fonts and a background image
- document optional execution via `python`

## Testing
- `python -m py_compile wanikani_dashboard/app.py`


------
https://chatgpt.com/codex/tasks/task_e_686e59c71200833192fe833f7f5a12ab